### PR TITLE
Updating sha256 for Merlin32.

### DIFF
--- a/merlin32.rb
+++ b/merlin32.rb
@@ -2,7 +2,7 @@ class Merlin32 < Formula
   desc "Multi-pass Cross Assembler for 6502/65c02/65c816 processors."
   homepage "http://www.brutaldeluxe.fr/products/crossdevtools/merlin/"
   url "http://www.brutaldeluxe.fr/products/crossdevtools/merlin/Merlin32_v1.0.zip"
-  sha256 "97bce524386a0d7a94cfe2292082090b7f96c371934ed8c819b0797fa16b5667"
+  sha256 "eb9203b22dba23e70382ab876112e826d4c6bb3d04004f712fd8a9df56778e39"
 
   def install
     merlin_dir = buildpath/"Merlin32_v1.0"


### PR DESCRIPTION
I tried to install Merlin32 and I guess the SHA changed at some point!

Error:
```
==> Installing merlin32 from lifepillar/appleii
==> Downloading http://www.brutaldeluxe.fr/products/crossdevtools/merlin/Merlin32_v1.0.zip
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: 97bce524386a0d7a94cfe2292082090b7f96c371934ed8c819b0797fa16b5667
Actual: eb9203b22dba23e70382ab876112e826d4c6bb3d04004f712fd8a9df56778e39
Archive: /Users/rob/Library/Caches/Homebrew/merlin32-1.0.zip
```
Pulled it independently and confirmed that SHA code.  

I don't know how to actually _test_ it, but I *can* copy and paste!  :-)
