### PR TITLE
Remove a2catalog alias

### DIFF
--- a/Aliases/a2catalog
+++ b/Aliases/a2catalog
@@ -1,1 +1,0 @@
-../Formula/apple-ii-disk-tools.rb


### PR DESCRIPTION
Remove alias orphaned since [843de1](https://github.com/lifepillar/homebrew-appleii/commit/843de156bda69df9eaf3187a054c98fbb96585d1).