### PR TITLE
remove deprecated check

### DIFF
--- a/Casks/zulufx8.rb
+++ b/Casks/zulufx8.rb
@@ -25,8 +25,6 @@ cask "zulufx8" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
-
   pkg "Double-Click to Install ZuluFX #{version.major}.pkg"
 
   uninstall pkgutil: "com.azulsystems.zulu.#{version.major}"


### PR DESCRIPTION
brew complains with a "Warning: Calling depends_on :macos => :yosemite is deprecated! There is no replacement."