### PR TITLE
New cask: Ample

### DIFF
--- a/Casks/ample.rb
+++ b/Casks/ample.rb
@@ -1,0 +1,25 @@
+cask "ample" do
+  version "0.251-u2,39"
+  sha256 "719818585d76eb25a462d37857ded5d1832e557f8bf0f979410b7a36ac5058a6"
+
+  url "https://github.com/ksherlock/ample/releases/download/r#{version.csv.second}/Ample-#{version.csv.second}.zip"
+  name "Ample"
+  desc "Apple Emulator Frontend for MAME"
+  homepage "https://github.com/ksherlock/ample"
+
+  livecheck do
+    url "https://ample.ksherlock.com/updates/appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
+
+  app "Ample.app"
+
+  zap trash: [
+    "~/Library/Application Support/Ample",
+    "~/Library/Caches/com.ksherlock.ample",
+    "~/Library/Preferences/com.ksherlock.ample.plist",
+  ]
+end


### PR DESCRIPTION
A slightly more user-friendly front-end for using MAME as an Apple II emulator.