### PR TITLE
Remove appcast from buckshot cask

### DIFF
--- a/Casks/buckshot.rb
+++ b/Casks/buckshot.rb
@@ -1,14 +1,13 @@
-cask 'buckshot' do
-  version '0.5'
-  sha256 '16babb4446509717e469fdd793c5feb3c4d361e5241bb7a425b378932588df15'
+cask "buckshot" do
+  version "0.5"
+  sha256 "16babb4446509717e469fdd793c5feb3c4d361e5241bb7a425b378932588df15"
 
   # github.com/digarok/buckshot was verified as official when first introduced to the cask
   url "https://github.com/digarok/buckshot/releases/download/v#{version}/buckshot.dmg",
     verified: "github.com/digarok/buckshot/"
-  appcast 'https://github.com/digarok/releases.atom'
-  name 'buckshot'
+  name "buckshot"
   desc "Apple II Image Converter Tool"
-  homepage 'https://apple2.gs/buckshot/'
+  homepage "https://apple2.gs/buckshot/"
 
-  app 'buckshot.app'
+  app "buckshot.app"
 end


### PR DESCRIPTION
Can now be checked with `brew livecheck buckshot`.