### PR TITLE
Remove appcast from gsport cask

### DIFF
--- a/Casks/gsport.rb
+++ b/Casks/gsport.rb
@@ -1,17 +1,15 @@
-cask 'gsport' do
-  version '0.31'
-  sha256 '00d5df71ff0ee6932ece28b248e100fdb378d05d958374223c15962b2529b913'
+cask "gsport" do
+  version "0.31"
+  sha256 "00d5df71ff0ee6932ece28b248e100fdb378d05d958374223c15962b2529b913"
 
   url "https://github.com/david-schmidt/gsport/releases/download/#{version}/gsport_#{version}.dmg",
     verified: "github.com/david-schmidt/gsport/"
-  appcast 'https://github.com/david-schmidt/gsport/releases.atom'
-  name 'GSPort'
-  desc 'Portable Apple IIGS emulator'
-  homepage 'https://david-schmidt.github.io/gsport/'
+  name "GSPort"
+  desc "Portable Apple IIGS emulator"
+  homepage "https://david-schmidt.github.io/gsport/"
 
-  app 'GSPort/GSPort.app'
+  # Copy the whole folder
+  app "GSPort"
 
-  caveats do
-    "A ROM file should be put in #{staged_path}/GSport."
-  end
+  caveats "A ROM file should be put in #{staged_path}/GSport."
 end


### PR DESCRIPTION
Can now be checked with `brew livecheck gsport`.

Also, copy the entire GSPort folder so it can find the config.txt it's bundled with.