### PR TITLE
Fix regex pattern for livecheck in lisaem.rb

### DIFF
--- a/Casks/lisaem.rb
+++ b/Casks/lisaem.rb
@@ -9,7 +9,7 @@ cask "lisaem" do
 
   livecheck do
     url :url
-    regex(/LisaEm[._-]v?(\d+(?:\.\d+)+[.\w-]*)-MacOS[._-](?:[.0-9]+)?[._-]arm64\.pkg/i)
+    regex(/LisaEm[._-]v?(\d+(?:\.\d+)+[.\w-]*)-MacOS[._-][.0-9]*[._-]arm64\.pkg/i)
   end
 
   pkg "LisaEm-#{version.csv.first}-#{version.csv.second}-MacOS-15.7_arm64.pkg"


### PR DESCRIPTION
This is the kind of warning brew spits out otherwise:

/opt/homebrew/Library/Taps/lifepillar/homebrew-appleii/Casks/lisaem.rb:12: warning: nested repeat operator '+' and '?' was replaced with '*' in regular expression